### PR TITLE
remove the unused and deprecated `multilingual` field from `book.toml`

### DIFF
--- a/bk/book.toml
+++ b/bk/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["John CD"]
 language = "en"
-multilingual = false
 # src = "src"  # the directory with the markdown sources, "src" by default
 title = "The Rust How-to Book"
 description = "A compendium of links, code snippets, and recipes for the Rust language and ecosystem."


### PR DESCRIPTION
See https://github.com/szabgab/public-mdbooks/issues/10