### PR TITLE
🔒 Fix hardcoded database password in create_tables example

### DIFF
--- a/bk/crates/cats/database/examples/postgres/aggregate_data.rs
+++ b/bk/crates/cats/database/examples/postgres/aggregate_data.rs
@@ -19,7 +19,7 @@ pub fn main() -> Result<(), Error> {
     // `postgresql://<user>:<password>@<host>/<db>`, for example
     // `postgresql://postgres:postgres@127.0.0.1/moma`.
     let url = std::env::var("PG_URL").unwrap_or_else(|_| {
-        "postgresql://postgres:password@localhost/moma".to_string()
+        "postgresql://postgres:<password>@localhost/moma".to_string()
     });
     let mut client = Client::connect(url, NoTls)?;
 

--- a/bk/crates/cats/database/examples/postgres/create_tables.rs
+++ b/bk/crates/cats/database/examples/postgres/create_tables.rs
@@ -16,7 +16,7 @@ pub fn main() -> anyhow::Result<()> {
     let url = std::env::var("PG_URL").unwrap_or_else(|_| {
         // Example connection URL:
         // `postgresql://postgres:postgres@localhost/library`.
-        "postgresql://postgres:password@localhost/library".to_string()
+        "postgresql://postgres:<password>@localhost/library".to_string()
     });
     let mut client = Client::connect(url, NoTls)?;
 

--- a/bk/crates/cats/database/examples/postgres/insert_query_data.rs
+++ b/bk/crates/cats/database/examples/postgres/insert_query_data.rs
@@ -19,7 +19,7 @@ pub fn main() -> Result<(), Error> {
     // postgresql://<user>:<password>@<host>/<db>,
     // for example postgresql://postgres:postgres@localhost/library
     let url = std::env::var("PG_URL").unwrap_or_else(|_| {
-        "postgresql://postgres:password@localhost/library".to_string()
+        "postgresql://postgres:<password>@localhost/library".to_string()
     });
     let mut client = Client::connect(url, NoTls)?;
 


### PR DESCRIPTION
🎯 **What:** Hardcoded password removed from postgres connection string fallback URLs across three example files: `create_tables.rs`, `aggregate_data.rs`, and `insert_query_data.rs`. Replaced the literal `"password"` with a generic placeholder `"<password>"`.

⚠️ **Risk:** The previous code contained hardcoded placeholder secrets within the fallback URL (e.g. `postgresql://postgres:password@localhost/library`). While these are just examples, it's generally a bad practice to ship any kind of credential (even if just `password`) in source code. This helps users of the code not accidentally run or copy/paste hardcoded creds into their own applications. If users copy-pasted the previous code into a real environment and relied on the fallback url, they might inadvertently use the weak default password.

🛡️ **Solution:** The `"password"` literal was changed to `"<password>"`. The URL remains a valid example of the format, but now clearly communicates to the user that they must provide a valid password rather than giving the illusion of a ready-to-run setup. This maintains the instructional purpose without supplying hardcoded default credentials. Tested to ensure everything still passes compilation and testing stages.

---
*PR created automatically by Jules for task [12609784665394900259](https://jules.google.com/task/12609784665394900259) started by @john-cd*