### PR TITLE
🔒 Remove hardcoded database credentials from tests

### DIFF
--- a/bk/crates/cats/database/examples/oracle/diesel_oci.rs
+++ b/bk/crates/cats/database/examples/oracle/diesel_oci.rs
@@ -95,10 +95,18 @@ fn establish_connection(
 
 #[test]
 fn require_external_svc() -> anyhow::Result<()> {
+    let _lock = super::ENV_MUTEX.lock().unwrap();
+    let username = std::env::var("TEST_ORACLE_DB_USERNAME")
+        .expect("TEST_ORACLE_DB_USERNAME must be set");
+    let password = std::env::var("TEST_ORACLE_DB_PASSWORD")
+        .expect("TEST_ORACLE_DB_PASSWORD must be set");
+    let db_url = std::env::var("TEST_ORACLE_DB_URL")
+        .expect("TEST_ORACLE_DB_URL must be set");
+
     unsafe {
-        env::set_var("ORACLE_DB_USERNAME", "SYS");
-        env::set_var("ORACLE_DB_PASSWORD", "CHANGE_ON_INSTALL");
-        env::set_var("ORACLE_DB_URL", "rust_howto_dev-redis-1");
+        env::set_var("ORACLE_DB_USERNAME", username);
+        env::set_var("ORACLE_DB_PASSWORD", password);
+        env::set_var("ORACLE_DB_URL", db_url);
     }
     main()?;
     Ok(())

--- a/bk/crates/cats/database/examples/oracle/main.rs
+++ b/bk/crates/cats/database/examples/oracle/main.rs
@@ -5,4 +5,8 @@ mod oracle;
 #[cfg(all(target_os = "linux", feature = "oracle"))]
 mod sibyl;
 
+#[cfg(feature = "oracle")]
+#[allow(dead_code)]
+pub(crate) static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 fn main() {}

--- a/bk/crates/cats/database/examples/oracle/oracle.rs
+++ b/bk/crates/cats/database/examples/oracle/oracle.rs
@@ -54,14 +54,18 @@ async fn main() -> Result<(), Error> {
 
 #[test]
 fn require_external_svc() -> anyhow::Result<()> {
+    let _lock = super::ENV_MUTEX.lock().unwrap();
+    let username = std::env::var("TEST_ORACLE_DB_USERNAME")
+        .expect("TEST_ORACLE_DB_USERNAME must be set");
+    let password = std::env::var("TEST_ORACLE_DB_PASSWORD")
+        .expect("TEST_ORACLE_DB_PASSWORD must be set");
+    let db_url = std::env::var("TEST_ORACLE_DB_URL")
+        .expect("TEST_ORACLE_DB_URL must be set");
+
     unsafe {
-        // Refer to the compose*.yaml files.
-        std::env::set_var("ORACLE_DB_USERNAME", "sysdba");
-        std::env::set_var("ORACLE_DB_PASSWORD", "Oracle_123");
-        std::env::set_var(
-            "ORACLE_DB_URL",
-            "rust_howto_dev-oracle-1:1521/ORCLCDB",
-        );
+        std::env::set_var("ORACLE_DB_USERNAME", username);
+        std::env::set_var("ORACLE_DB_PASSWORD", password);
+        std::env::set_var("ORACLE_DB_URL", db_url);
     }
     main()?;
     Ok(())

--- a/bk/crates/cats/database/examples/postgres/aggregate_data.rs
+++ b/bk/crates/cats/database/examples/postgres/aggregate_data.rs
@@ -18,9 +18,7 @@ pub fn main() -> Result<(), Error> {
     // The connection URL is formatted as
     // `postgresql://<user>:<password>@<host>/<db>`, for example
     // `postgresql://postgres:postgres@127.0.0.1/moma`.
-    let url = std::env::var("PG_URL").unwrap_or_else(|_| {
-        "postgresql://postgres:password@localhost/moma".to_string()
-    });
+    let url = std::env::var("PG_URL").expect("PG_URL must be set");
     let mut client = Client::connect(&url, NoTls)?;
 
     for row in client.query(

--- a/bk/crates/cats/database/examples/postgres/create_tables.rs
+++ b/bk/crates/cats/database/examples/postgres/create_tables.rs
@@ -13,11 +13,7 @@ pub fn main() -> anyhow::Result<()> {
     // Establish a connection to the PostgreSQL database.
     // The connection URL format is
     // `postgresql://<user>:<password>@<host>/<db>`.
-    let url = std::env::var("PG_URL").unwrap_or_else(|_| {
-        // Example connection URL:
-        // `postgresql://postgres:postgres@localhost/library`.
-        "postgresql://postgres:password@localhost/library".to_string()
-    });
+    let url = std::env::var("PG_URL").expect("PG_URL must be set");
     let mut client = Client::connect(&url, NoTls)?;
 
     client.batch_execute(

--- a/bk/crates/cats/database/examples/postgres/insert_query_data.rs
+++ b/bk/crates/cats/database/examples/postgres/insert_query_data.rs
@@ -19,9 +19,7 @@ pub fn main() -> Result<(), Error> {
     // The connection URL is formatted as
     // postgresql://<user>:<password>@<host>/<db>,
     // for example postgresql://postgres:postgres@localhost/library
-    let url = std::env::var("PG_URL").unwrap_or_else(|_| {
-        "postgresql://postgres:password@localhost/library".to_string()
-    });
+    let url = std::env::var("PG_URL").expect("PG_URL must be set");
     let mut client = Client::connect(&url, NoTls)?;
 
     // Create a HashMap to store author names and their respective countries.

--- a/bk/crates/cats/database/examples/postgres/main.rs
+++ b/bk/crates/cats/database/examples/postgres/main.rs
@@ -26,11 +26,10 @@ fn main() -> anyhow::Result<()> {
 #[test]
 fn require_external_svc() -> anyhow::Result<()> {
     let _lock = ENV_MUTEX.lock().unwrap();
+    let test_url =
+        std::env::var("TEST_PG_URL").expect("TEST_PG_URL must be set");
     unsafe {
-        std::env::set_var(
-            "PG_URL",
-            "postgresql://postgres:password@rust_howto_dev-postgres-1/library",
-        );
+        std::env::set_var("PG_URL", test_url);
     }
     main()?;
     Ok(())

--- a/bk/crates/cats/database/examples/postgres/tokio_postgres.rs
+++ b/bk/crates/cats/database/examples/postgres/tokio_postgres.rs
@@ -88,14 +88,10 @@ async fn main() -> Result<(), tokio_postgres::Error> {
 #[tokio::test]
 async fn require_external_svc() -> anyhow::Result<()> {
     let _lock = super::ENV_MUTEX.lock().unwrap();
-    let test_url = std::env::var("TEST_PG_URL").unwrap_or_else(|_| {
-        "host=rust_howto_dev-postgres-1 user=postgres password=password dbname=library".to_string()
-    });
+    let test_url =
+        std::env::var("TEST_PG_URL").expect("TEST_PG_URL must be set");
     unsafe {
-        std::env::set_var(
-            "PG_URL",
-            "host=rust_howto_dev-postgres-1 user=postgres password=password dbname=library",
-        );
+        std::env::set_var("PG_URL", test_url);
     }
     tokio::task::spawn_blocking(|| main()).await??;
     Ok(())


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
This PR removes hardcoded database credentials from the test suites for Oracle and PostgreSQL examples.

⚠️ **Risk:** The potential impact if left unfixed
Hardcoded passwords in tests can be accidentally committed to source control, leading to unauthorized access to database systems. Even if they are intended for local or development environments, they represent poor security hygiene and can be leaked if the codebase is shared or audited.

🛡️ **Solution:** How the fix addresses the vulnerability
- Replaced hardcoded credentials with environment variable lookups (`TEST_ORACLE_DB_USERNAME`, `TEST_ORACLE_DB_PASSWORD`, `TEST_ORACLE_DB_URL`, and `TEST_PG_URL`).
- Introduced a `pub(crate) static ENV_MUTEX` in `bk/crates/cats/database/examples/oracle/main.rs` to synchronize environment variable modifications during tests, ensuring thread safety.
- Used `.expect()` to fail fast with a descriptive message if required environment variables are not set.
- Consistent application of these changes across `diesel_oci.rs`, `oracle.rs`, `tokio_postgres.rs`, and other relevant PostgreSQL example files.

---
*PR created automatically by Jules for task [9315665436421260698](https://jules.google.com/task/9315665436421260698) started by @john-cd*