### PR TITLE
docs: enhance arrayvec example and add missing methods

### DIFF
--- a/bk/crates/cats/data_structures/examples/stack_allocated/arrayvec.rs
+++ b/bk/crates/cats/data_structures/examples/stack_allocated/arrayvec.rs
@@ -4,37 +4,63 @@ use arrayvec::ArrayVec;
 
 /// This example demonstrates basic usage of `ArrayVec`.
 fn main() {
-    // Create an empty `ArrayVec` of capacity 2:
+    // Create an empty `ArrayVec` of capacity 5:
     // The capacity is of type `usize` but is range-limited to `u32::MAX`.
-    let mut array = ArrayVec::<_, 2>::new();
-    assert_eq!(array.capacity(), 2);
+    let mut array = ArrayVec::<_, 5>::new();
+    assert_eq!(array.capacity(), 5);
 
     // Push some elements into the `ArrayVec`:
     array.push(1);
     array.push(2);
+
+    // Try extending from a slice:
+    let _ = array.try_extend_from_slice(&[3, 4, 5]);
     assert!(array.is_full());
+    assert_eq!(&array[..], &[1, 2, 3, 4, 5]);
 
     // Pushing beyond the capacity will result in a panic:
-    // ERROR: array.push(3);
+    // ERROR: array.push(6);
 
-    let overflow = array.try_push(3);
+    let overflow = array.try_push(6);
     assert!(overflow.is_err());
 
     // Access elements:
     for i in 0..array.len() {
         println!("Element at index {}: {}", i, array[i]);
     }
-    assert_eq!(&array[..], &[1, 2]);
+    assert_eq!(&array[..], &[1, 2, 3, 4, 5]);
 
     // Build from an array:
-    let mut array2: ArrayVec<i32, 3> = ArrayVec::from([1, 2, 3]);
+    let mut array2: ArrayVec<i32, 5> = ArrayVec::from([1, 2, 3, 4, 5]);
 
     // Pop an element from the `ArrayVec`:
     if let Some(value) = array2.pop() {
-        println!("Popped value: {value}");
+        println!("Popped value: {value}"); // 5
     }
-    assert_eq!(array2.len(), 2);
+    assert_eq!(array2.len(), 4);
     assert!(!array2.is_empty());
+
+    // Insert an element:
+    array2.insert(2, 99);
+    assert_eq!(&array2[..], &[1, 2, 99, 3, 4]);
+
+    // Remove an element:
+    let removed = array2.remove(2);
+    assert_eq!(removed, 99);
+    assert_eq!(&array2[..], &[1, 2, 3, 4]);
+
+    // Retain elements based on a condition:
+    array2.retain(|x| *x % 2 == 0);
+    assert_eq!(&array2[..], &[2, 4]);
+
+    // Drain elements:
+    let drained: Vec<_> = array2.drain(..).collect();
+    assert_eq!(drained, vec![2, 4]);
+    assert!(array2.is_empty());
+
+    // Clear the array
+    array.clear();
+    assert!(array.is_empty());
 }
 // ANCHOR_END: example
 
@@ -42,4 +68,3 @@ fn main() {
 fn test() {
     main();
 }
-// TODO review


### PR DESCRIPTION
Reviewed and enhanced the `ArrayVec` example in `bk/crates/cats/data_structures/examples/stack_allocated/arrayvec.rs`.

Changes made:
- Added `try_extend_from_slice` example.
- Added `insert` and `remove` method examples.
- Added an example using `retain` to filter elements.
- Added a `drain` example.
- Added a `clear` example.
- Formatted the file using `cargo +nightly fmt`.
- Removed the obsolete `// TODO review` comment.

---
*PR created automatically by Jules for task [16019231676369841422](https://jules.google.com/task/16019231676369841422) started by @john-cd*