### PR TITLE
Update smallvec example to use assertions

### DIFF
--- a/bk/crates/cats/data_structures/examples/stack_allocated/smallvec.rs
+++ b/bk/crates/cats/data_structures/examples/stack_allocated/smallvec.rs
@@ -21,6 +21,9 @@ fn main() {
     // We can also initialize it via a macro:
     let mut small_vec: SmallVec<[i32; 4]> = smallvec![1, 2, 3, 4];
 
+    // Print the current state of the SmallVec.
+    println!("SmallVec (inline): {small_vec:?}");
+
     // Push beyond the inline capacity, causing a heap allocation.
     small_vec.push(5);
 
@@ -29,13 +32,22 @@ fn main() {
     // The capacity grows upon spilling (typically doubling the original capacity)
     assert_eq!(small_vec.capacity(), 8);
 
+    // Print the state of the SmallVec after pushing beyond capacity.
+    println!("SmallVec (heap-allocated): {small_vec:?}");
+
     // Access elements using indexing.
+    for i in 0..small_vec.len() {
+        println!("Element at index {i}: {}", small_vec[i]);
+    }
     assert_eq!(small_vec[0], 1);
     assert_eq!(small_vec.last(), Some(&5));
 
     // Pop an element from the SmallVec.
     let value = small_vec.pop();
     assert_eq!(value, Some(5));
+
+    // Print the state of the SmallVec after popping.
+    println!("SmallVec after popping: {small_vec:?}");
 
     // SmallVec points to a slice, so we can use normal slice indexing and
     // other slice methods.

--- a/bk/crates/cats/data_structures/examples/stack_allocated/smallvec.rs
+++ b/bk/crates/cats/data_structures/examples/stack_allocated/smallvec.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code)]
 // ANCHOR: example
-use smallvec::SmallVec;
-use smallvec::smallvec;
+use smallvec::{smallvec, SmallVec};
 
 fn main() {
     // Create a SmallVec with a small inline capacity of 4.
@@ -15,35 +14,36 @@ fn main() {
     small_vec.push(3);
     small_vec.push(4);
 
+    assert_eq!(small_vec.len(), 4);
+    // Elements are stored inline (no heap allocation yet)
+    assert!(!small_vec.spilled());
+
     // We can also initialize it via a macro:
     let mut small_vec: SmallVec<[i32; 4]> = smallvec![1, 2, 3, 4];
-
-    // Print the current state of the SmallVec.
-    println!("SmallVec (inline): {small_vec:?}");
 
     // Push beyond the inline capacity, causing a heap allocation.
     small_vec.push(5);
 
-    // Print the state of the SmallVec after pushing beyond capacity.
-    println!("SmallVec (heap-allocated): {small_vec:?}");
+    // The vector has now spilled over to the heap
+    assert!(small_vec.spilled());
+    // The capacity grows upon spilling (typically doubling the original capacity)
+    assert_eq!(small_vec.capacity(), 8);
 
     // Access elements using indexing.
-    for i in 0..small_vec.len() {
-        println!("Element at index {i}: {}", small_vec[i]);
-    }
+    assert_eq!(small_vec[0], 1);
+    assert_eq!(small_vec.last(), Some(&5));
 
     // Pop an element from the SmallVec.
-    if let Some(value) = small_vec.pop() {
-        println!("Popped value: {value}");
-    }
-
-    // Print the state of the SmallVec after popping.
-    println!("SmallVec after popping: {small_vec:?}");
+    let value = small_vec.pop();
+    assert_eq!(value, Some(5));
 
     // SmallVec points to a slice, so we can use normal slice indexing and
-    // other methods to access its contents.
+    // other slice methods.
     small_vec[0] = small_vec[1] + small_vec[2];
     small_vec.sort();
+
+    let expected: SmallVec<[i32; 4]> = smallvec![2, 3, 4, 5];
+    assert_eq!(small_vec, expected);
 }
 // ANCHOR_END: example
 
@@ -51,4 +51,3 @@ fn main() {
 fn test() {
     main();
 }
-// TODO review


### PR DESCRIPTION
This PR refactors the `smallvec` example to be self-verifying.
Instead of just printing output, it uses assertions (`assert!`, `assert_eq!`) to verify the expected length, heap allocation status (`spilled()`), and contents, making the example much stronger as a doc test and removing the `TODO review` comment.

---
*PR created automatically by Jules for task [12921667059909098140](https://jules.google.com/task/12921667059909098140) started by @john-cd*