### PR TITLE
fix async compression example

### DIFF
--- a/bk/crates/cats/compression/Cargo.toml
+++ b/bk/crates/cats/compression/Cargo.toml
@@ -25,8 +25,9 @@ anyhow = "1.0.100"
 # TODO add example for async_zip?
 # async_zip = "0.0.17"
 
-# FIXME finish async_compresssion example
-# bytes = "1.9.0"
-# futures = "0.3.31"
-# tokio = { version = "1.44.2", features = ["macros", "rt-multi-thread"] }
-# tokio-util = { version = "0.7.13", features = ["codec"] }
+
+bytes = "1.9.0"
+futures = "0.3.31"
+tokio = { version = "1.44.2", features = ["macros", "rt-multi-thread", "fs", "io-util", "io-std"] }
+tokio-util = { version = "0.7.13", features = ["codec"] }
+async-compression = { version = "0.4.18", features = ["tokio", "gzip"] }

--- a/bk/crates/cats/compression/examples/compression/async_compression.rs
+++ b/bk/crates/cats/compression/examples/compression/async_compression.rs
@@ -1,130 +1,90 @@
 #![allow(dead_code)]
-// // ANCHOR: example
-// // COMING SOON
-// // ANCHOR_END: example
-// use std::io::Result as IoResult;
+// ANCHOR: example
+use std::io::Result as IoResult;
 
-// use bytes::Bytes;
-// use flate2::Compression;
-// use flate2::read::GzDecoder;
-// use flate2::write::GzEncoder;
-// use futures::stream::StreamExt;
-// use futures::stream::TryStreamExt;
-// use tokio::fs::File;
-// use tokio::io::AsyncReadExt;
-// use tokio::io::AsyncWriteExt;
-// use tokio_util::codec::BytesCodec;
-// use tokio_util::codec::FramedRead;
+use async_compression::tokio::bufread::GzipDecoder;
+use async_compression::tokio::write::GzipEncoder;
+use tokio::fs::File;
+use tokio::io::AsyncWriteExt;
+use tokio::io::BufReader;
 
-// #[tokio::main]
-// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//     let input_filename = "temp/uncompressed.txt";
-//     let compressed_filename = "temp/compressed.gz";
-//     let decompressed_filename = "temp/decompressed.txt";
+#[tokio::main]
+pub async fn main() -> anyhow::Result<()> {
+    let input_filename = "temp/uncompressed_async.txt";
+    let compressed_filename = "temp/compressed_async.gz";
+    let decompressed_filename = "temp/decompressed_async.txt";
 
-//     // 1. Asynchronously create an uncompressed file.
-//     let mut input_file = File::create(input_filename).await?;
-//     input_file.write_all(b"This is some sample data.\n").await?;
-//     input_file.write_all(b"It has multiple lines.\n").await?;
-//     drop(input_file);
+    // 1. Asynchronously create an uncompressed file.
+    let mut input_file = File::create(input_filename).await?;
+    input_file.write_all(b"This is some sample data.\n").await?;
+    input_file.write_all(b"It has multiple lines.\n").await?;
+    drop(input_file);
 
-//     println!("Created '{input_filename}'");
+    println!("Created '{input_filename}'");
 
-//     // 2. Asynchronously compress the file.
-//     println!(
-//         "Compressing '{input_filename}' to '{compressed_filename}'..."
-//     );
-//     compress_file_async(input_filename, compressed_filename).await?;
-//     println!("Compression complete.");
+    // 2. Asynchronously compress the file.
+    println!(
+        "Compressing '{input_filename}' to '{compressed_filename}'..."
+    );
+    compress_file_async(input_filename, compressed_filename).await?;
+    println!("Compression complete.");
 
-//     // 3. Asynchronously decompress the file.
-//     println!(
-//         "Decompressing '{compressed_filename}' to
-// '{decompressed_filename}'...",     );
-//     decompress_file_async(compressed_filename, decompressed_filename).await?;
-//     println!("Decompression complete.");
+    // 3. Asynchronously decompress the file.
+    println!(
+        "Decompressing '{compressed_filename}' to '{decompressed_filename}'..."
+    );
+    decompress_file_async(compressed_filename, decompressed_filename).await?;
+    println!("Decompression complete.");
 
-//     // 4. Verify the decompressed content.
-//     let original_content = tokio::fs::read_to_string(input_filename).await?;
-//     let decompressed_content =
-//         tokio::fs::read_to_string(decompressed_filename).await?;
+    // 4. Verify the decompressed content.
+    let original_content = tokio::fs::read_to_string(input_filename).await?;
+    let decompressed_content =
+        tokio::fs::read_to_string(decompressed_filename).await?;
 
-//     if original_content == decompressed_content {
-//         println!("Decompressed content matches the original.");
-//     } else {
-//         eprintln!("Error: Decompressed content does NOT match the
-// original!");     }
+    if original_content == decompressed_content {
+        println!("Decompressed content matches the original.");
+    } else {
+        eprintln!("Error: Decompressed content does NOT match the original!");
+    }
 
-//     Ok(())
-// }
+    Ok(())
+}
 
-// async fn compress_file_async(
-//     source_path: &str,
-//     dest_path: &str,
-// ) -> IoResult<()> {
-//     // Asynchronously opens the file for reading.
-//     let source_file = File::open(source_path).await?;
-//     // Creates a `FramedRead` around the source file with `BytesCodec` to
-//     // read data in chunks of Bytes. The `FramedRead` turns the asynchronous
-//     // File (which implements `AsyncRead`) into an asynchronous stream (`impl
-//     // Stream<Item = Result<Bytes, io::Error>>`).
-//     let mut reader = FramedRead::new(source_file, BytesCodec::new());
+async fn compress_file_async(
+    source_path: &str,
+    dest_path: &str,
+) -> IoResult<()> {
+    let mut source_file = File::open(source_path).await?;
+    let dest_file = File::create(dest_path).await?;
 
-//     let dest_file = File::create(dest_path).await?;
-//     let mut encoder = GzEncoder::new(dest_file, Compression::default());
+    let mut encoder = GzipEncoder::new(dest_file);
+    tokio::io::copy(&mut source_file, &mut encoder).await?;
+    encoder.shutdown().await?;
 
-//     // Iterates through the asynchronous stream of bytes from the source file
-//     // using `reader.next().await`. `reader` implements the Stream trait from
-//     // the futures crate. `.next()` asynchronously waits for the next item (a
-//     // `Result<Bytes, io::Error>`) from the stream. It returns
-//     // `Some(Result<Bytes, io::Error>)` if an item is available and `None`
-//     // when the stream is exhausted (end of file).
-//     while let Some(result) = reader.next().await {
-//         let bytes = result?;
-//         // For each chunk of bytes read, it asynchronously writes the chunk
-//          // to the `GzEncoder` using `encoder.write_all().await?`. The
-//          // `GzEncoder` handles the compression internally as data is written
-//          // to it.
-//          encoder.write_all(&bytes).await?;
-//     }
+    Ok(())
+}
 
-//     // Ensure that all buffered compressed data is written to the destination
-//     // file and the gzip stream is properly finalized.
-//     encoder.finish().await?;
-//     Ok(())
-// }
+async fn decompress_file_async(
+    source_path: &str,
+    dest_path: &str,
+) -> IoResult<()> {
+    let source_file = File::open(source_path).await?;
+    let mut dest_file = File::create(dest_path).await?;
 
-// async fn decompress_file_async(
-//     source_path: &str,
-//     dest_path: &str,
-// ) -> IoResult<()> {
-//     let source_file = File::open(source_path).await?;
-//     // Creates a `GzDecoder` wrapped around the source file. `GzDecoder` from
-//     // `flate2::read` implements `AsyncRead`.
-//     let decoder = GzDecoder::new(source_file);
-//     // Creates a `FramedRead` around the `GzDecoder` with `BytesCodec` to
-//     // read the decompressed data in chunks.
-//     let mut reader = FramedRead::new(decoder, BytesCodec::new());
+    let reader = BufReader::new(source_file);
+    let mut decoder = GzipDecoder::new(reader);
+    tokio::io::copy(&mut decoder, &mut dest_file).await?;
 
-//     let dest_file = File::create(dest_path).await?;
-//     let mut writer = dest_file;
+    Ok(())
+}
 
-//     while let Some(result) = reader.next().await {
-//         let bytes = result?;
-//         writer.write_all(&bytes).await?;
-//     }
-
-//     Ok(())
-// }
-
-// #[test]
-// fn test() -> anyhow::Result<()> {
-//     use std::fs;
-//     if !fs::exists("temp")? {
-//        fs::create_dir("temp")?;
-//     }
-//     main()?;
-//     Ok(())
-// }
-
-// TODO review the above; cover async_zip ?
+#[test]
+fn test() -> anyhow::Result<()> {
+    use std::fs;
+    if !fs::exists("temp")? {
+       fs::create_dir("temp")?;
+    }
+    main()?;
+    Ok(())
+}
+// ANCHOR_END: example


### PR DESCRIPTION
Uncomment the example code in `async_compression.rs` and update it to
use `async-compression` crate with `tokio` backend instead of the older
commented-out approach. Also fixes up dependencies in `Cargo.toml`.

---
*PR created automatically by Jules for task [3656782818453629907](https://jules.google.com/task/3656782818453629907) started by @john-cd*