### PR TITLE
docs(aerospace-sim): remove TODOs and update related topics

### DIFF
--- a/later/src/categories/aerospace_simulation/aerospace_simulation.md
+++ b/later/src/categories/aerospace_simulation/aerospace_simulation.md
@@ -16,6 +16,3 @@
 {{#include refs.incl.md}}
 {{#include ../../refs/link-refs.md}}
 
-<div class="hidden">
-[aerospace_simulation: write](https://github.com/john-cd/rust_howto/issues/199)
-</div>

--- a/later/src/categories/aerospace_simulation/index.md
+++ b/later/src/categories/aerospace_simulation/index.md
@@ -60,11 +60,9 @@ Consider using:
 
 ## Related Topics
 
-FIXME
+- [[aerospace | Aerospace]].
+- [[simulation | Simulation]].
 
 {{#include refs.incl.md}}
 {{#include ../../refs/link-refs.md}}
 
-<div class="hidden">
-TODO write
-</div>


### PR DESCRIPTION
Removed "FIXME" and hidden "TODO" sections in `later/src/categories/aerospace_simulation/index.md` and `aerospace_simulation.md` and added correct links to related topics.

---
*PR created automatically by Jules for task [3185733504673099266](https://jules.google.com/task/3185733504673099266) started by @john-cd*