### PR TITLE
docs: add monorepo and git submodules section

### DIFF
--- a/bk/src/code-organization/code_organization_by_project_type.incl.md
+++ b/bk/src/code-organization/code_organization_by_project_type.incl.md
@@ -7,3 +7,4 @@
 | [Create a Prelude for Commonly Used Items of Your Library][ex~code-organization~prelude] |
 | [Organize the Code of a Binary Crate][ex~code-organization~binary-crate-organization] |
 | [Organize Large Projects Using a Workspace][ex~code-organization~large-projects] |
+| [Monorepos and Git Submodules][ex~code-organization~monorepos-and-git-submodules] |

--- a/bk/src/code-organization/code_organization_by_project_type.md
+++ b/bk/src/code-organization/code_organization_by_project_type.md
@@ -289,6 +289,15 @@ members = [ "lib1", "lib2", "main_lib" ]
 
 Confusingly, a workspace [`Cargo.toml`][book~cargo~cargo-toml]↗{{hi:Cargo.toml}} can also include a 'root package' in addition to member crates. That lets you place the code of the main library or executable in e.g. a [`src`][book~cargo~project-layout]↗{{hi:src folder}} folder directly under the workspace root.
 
+## Monorepos and Git Submodules {#monorepos-and-git-submodules}
+
+As projects scale, you may encounter the concept of a "monorepo" (monolithic repository). A monorepo is a single version control repository that houses multiple, often logically independent projects or crates. Cargo workspaces (discussed above) are naturally well-suited for a monorepo architecture, as they allow you to manage multiple related packages within a single Git repository while sharing dependencies and a common `Cargo.lock`.
+
+If you have independent repositories that need to be included within a larger project, you can use [Git submodules][git~submodules]↗. Submodules allow you to keep a Git repository as a subdirectory of another Git repository, letting you clone another project into your project while keeping your commits separate.
+
+When working with Git submodules in your Rust projects, remember this crucial best practice:
+**Always push changes in the submodule to its own remote repository before committing and pushing the updated submodule pointer in the parent repository.** If you commit the parent repository pointing to a local submodule commit that hasn't been pushed, other contributors or CI systems will encounter a broken build because they cannot fetch that specific submodule commit.
+
 ## Related Topics {#related-topics .skip}
 
 - [[package_layout | Package Layout]].

--- a/bk/src/code-organization/index.md
+++ b/bk/src/code-organization/index.md
@@ -45,6 +45,3 @@ Rust's "module system" helps structure your projects effectively. It gives fine-
 {{#include refs.incl.md}}
 {{#include ../refs/link-refs.md}}
 
-<div class="hidden">
-TODO cover monorepo / git submodules?
-</div>


### PR DESCRIPTION
This PR addresses the TODO about documenting monorepos and git submodules in the `code_organization` chapter of the book. 

Specifically:
- It introduces a new `Monorepos and Git Submodules` section in `code_organization_by_project_type.md`.
- Updates the `code_organization_by_project_type.incl.md` index reference.
- Removes the related `TODO` marker from `index.md`.
- Also details best practices when using git submodules inside monorepos, especially around pushing the submodule's changes.

---
*PR created automatically by Jules for task [13321221154047557646](https://jules.google.com/task/13321221154047557646) started by @john-cd*