### PR TITLE
docs: document rust-analyzer settings for large codebases

### DIFF
--- a/bk/drafts/contributing/vscode.md
+++ b/bk/drafts/contributing/vscode.md
@@ -1,8 +1,15 @@
 # VS Code Configuration
 
-TODO document rust-analyzer settings that works with large codebases like this book.
-
 ## `rust-analyzer` Configuration {#rust-analyzer-configuration}
+
+For large codebases, you may want to prevent `rust-analyzer` from starting automatically on workspace load to save resources, and exclude build directories like `target/` from VS Code's search index:
+
+```json
+"search.exclude": {
+    "**/target": true
+},
+"rust-analyzer.initializeStopped": true,
+```
 
 Main `settings.json` under e.g. `C:\Users\<user_name>\AppData\Roaming\Code\User`
 
@@ -12,10 +19,11 @@ Main `settings.json` under e.g. `C:\Users\<user_name>\AppData\Roaming\Code\User`
 {
     "rust-analyzer.linkedProjects": [
         "bk/crates/Cargo.toml",
+        "later/crates/Cargo.toml",
+        "mdbook-utils/Cargo.toml",
         "playground/Cargo.toml",
         "publish/Cargo.toml",
         "tools/Cargo.toml",
-        "wip/Cargo.toml",
         "xmpl/Cargo.toml"
     ],
     // More configuration settings...


### PR DESCRIPTION
This PR addresses the TODO in `bk/drafts/contributing/vscode.md` by documenting the recommended `rust-analyzer` settings for navigating this large codebase. It replaces the TODO string with an explanation and JSON snippet for excluding build directories (`**/target`) and preventing `rust-analyzer` from starting automatically on workspace load (`"rust-analyzer.initializeStopped": true`), ensuring VS Code remains responsive and resource-efficient. It also updates the `linkedProjects` example list to reflect the current configuration found in `.vscode/settings.json`.

---
*PR created automatically by Jules for task [16284270143501790815](https://jules.google.com/task/16284270143501790815) started by @john-cd*