### PR TITLE
Add wasm js examples

### DIFF
--- a/later/crates/Cargo.lock
+++ b/later/crates/Cargo.lock
@@ -15000,8 +15000,11 @@ name = "wasm"
 version = "0.1.2"
 dependencies = [
  "anyhow",
+ "js-sys",
+ "wasm-bindgen",
  "wasmer",
  "wasmtime",
+ "web-sys",
  "yew",
 ]
 

--- a/later/crates/cats/wasm/Cargo.toml
+++ b/later/crates/cats/wasm/Cargo.toml
@@ -16,7 +16,9 @@ autolib = false
 
 [dependencies]
 # LATER add example?
-# js-sys = "0.3.77"
+js-sys = "0.3.77"
+web-sys = { version = "0.3.77", features = ["Window"] }
+wasm-bindgen = "0.2.100"
 wasmer = "6.0.1"
 wasmtime = { version = "36.0.7", optional = true } # Heavy compile
 yew = { version = "0.21.0", features = ["csr"] }

--- a/later/crates/cats/wasm/examples/interfacing_with_javascript/js_sys.rs
+++ b/later/crates/cats/wasm/examples/interfacing_with_javascript/js_sys.rs
@@ -1,0 +1,14 @@
+#![allow(dead_code)]
+// ANCHOR: example
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+#[cfg(target_arch = "wasm32")]
+use js_sys::Date;
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+pub fn get_current_time() -> String {
+    let date = Date::new_0();
+    String::from(date.to_utc_string())
+}
+// ANCHOR_END: example

--- a/later/crates/cats/wasm/examples/interfacing_with_javascript/main.rs
+++ b/later/crates/cats/wasm/examples/interfacing_with_javascript/main.rs
@@ -1,2 +1,6 @@
-// LATER
-fn main() {}
+mod js_sys;
+mod web_sys;
+
+fn main() {
+    println!("Run with specific examples.");
+}

--- a/later/crates/cats/wasm/examples/interfacing_with_javascript/web_sys.rs
+++ b/later/crates/cats/wasm/examples/interfacing_with_javascript/web_sys.rs
@@ -1,0 +1,15 @@
+#![allow(dead_code)]
+// ANCHOR: example
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+#[cfg(target_arch = "wasm32")]
+use web_sys::window;
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+pub fn show_alert() {
+    if let Some(window) = window() {
+        window.alert_with_message("Hello from Rust!").expect("Failed to show alert");
+    }
+}
+// ANCHOR_END: example

--- a/later/src/categories/wasm/interfacing_with_javascript.md
+++ b/later/src/categories/wasm/interfacing_with_javascript.md
@@ -18,14 +18,18 @@ Bindings for all JS global objects and functions found in all JS environments li
 
 This does not include any Web, [Node][p~node], or any other JS environment APIs. Only the things that are guaranteed to exist in the global scope by the ECMAScript standard.
 
-TODO add example ?
+```rust,editable
+{{#include ../../../crates/cats/wasm/examples/interfacing_with_javascript/js_sys.rs:example}}
+```
 
 ## Accessing DOM and Web APIs via Rust {#accessing-dom .skip}
 
 The [`web-sys`][c~web-sys~crates.io]↗{{hi:web-sys}} crate provides Rust bindings to the Web's APIs, allowing you to interact with the DOM, Canvas, WebGL, and other browser features.
 Essentially, [`web-sys`][c~web-sys~docs]↗{{hi:web-sys}} is the bridge that lets your Rust code talk to the browser.
 
-TODO add example ?
+```rust,editable
+{{#include ../../../crates/cats/wasm/examples/interfacing_with_javascript/web_sys.rs:example}}
+```
 
 ## Calling Rust/WASM Functions from JavaScript {#calling-rust-wasm .skip}
 


### PR DESCRIPTION
Added js-sys and web-sys examples to interfacing_with_javascript.md removing TODOs. Updated dependencies to include js-sys, web-sys, and wasm-bindgen.

---
*PR created automatically by Jules for task [1426061170732129306](https://jules.google.com/task/1426061170732129306) started by @john-cd*