### PR TITLE
Add example for seaography

### DIFF
--- a/bk/crates/cats/database/examples/query_builders_orms/main.rs
+++ b/bk/crates/cats/database/examples/query_builders_orms/main.rs
@@ -2,6 +2,8 @@
 mod diesel1;
 #[cfg(feature = "sea_orm")]
 mod sea_orm;
+#[cfg(feature = "sea_orm")]
+mod seaography;
 #[cfg(feature = "sqlx")]
 mod sqlx;
 

--- a/bk/crates/cats/database/examples/query_builders_orms/seaography.rs
+++ b/bk/crates/cats/database/examples/query_builders_orms/seaography.rs
@@ -1,0 +1,11 @@
+#![allow(dead_code)]
+// // ANCHOR: example
+// // COMING SOON
+// // ANCHOR_END: example
+
+fn main() {}
+
+#[test]
+fn require_external_svc() {
+    main();
+}

--- a/bk/crates/cats/database/examples/query_builders_orms/seaography.rs
+++ b/bk/crates/cats/database/examples/query_builders_orms/seaography.rs
@@ -1,7 +1,18 @@
 #![allow(dead_code)]
-// // ANCHOR: example
-// // COMING SOON
-// // ANCHOR_END: example
+// ANCHOR: example
+// Seaography is an automated GraphQL framework for SeaORM.
+// You do not write query builder logic by hand. Instead, you use the seaography-cli
+// to auto-generate the server from your existing database:
+//
+// 1. Generate entities using sea-orm-cli:
+//    sea-orm-cli generate entity -o src/entities -u sqlite://sakila.db --seaography
+//
+// 2. Generate the GraphQL server project using seaography-cli:
+//    seaography-cli ./ src/entities sqlite://sakila.db seaography-sqlite-example
+//
+// 3. Start the server:
+//    cd seaography-sqlite-example && cargo run
+// ANCHOR_END: example
 
 fn main() {}
 

--- a/bk/drafts/categories/database/query_builders_orms.md
+++ b/bk/drafts/categories/database/query_builders_orms.md
@@ -24,7 +24,9 @@ Built on top of [`sqlx`][c~sqlx~docs]↗{{hi:sqlx}} (see above). There is also a
 {{#include ../../../crates/cats/database/examples/query_builders_orms/sea_orm.rs:example}}
 ```
 
-TODO add example for seography
+```rust,editable,noplayground
+{{#include ../../../crates/cats/database/examples/query_builders_orms/seaography.rs:example}}
+```
 
 ## `diesel` {#diesel}
 


### PR DESCRIPTION
This PR adds the missing seaography example.

1.  Created the `seaography.rs` file under `bk/crates/cats/database/examples/query_builders_orms/` with the "COMING SOON" placeholder matching `sea_orm`.
2.  Updated `bk/crates/cats/database/examples/query_builders_orms/main.rs` to include `mod seaography;` when the `sea_orm` feature is enabled.
3.  Updated `bk/drafts/categories/database/query_builders_orms.md` to reference the new `seaography.rs` example instead of the "TODO" block.

---
*PR created automatically by Jules for task [15526485673342319307](https://jules.google.com/task/15526485673342319307) started by @john-cd*