### PR TITLE
chore: remove temporary workaround for rust linker issue #141626

### DIFF
--- a/bk/crates/.cargo/config.toml
+++ b/bk/crates/.cargo/config.toml
@@ -177,11 +177,6 @@ opt-level = 0
 # runner = "..."            # wrapper to run executables
 # rustflags = ["...", "..."]  # custom flags for `rustc`
 
-# error: linking with `link.exe` failed: exit code: 0xc0000409
-# https://github.com/rust-lang/rust/issues/141626
-# (can be removed once link.exe is fixed)
-[target.x86_64-pc-windows-msvc]
-linker = "rust-lld"
 
 # [target.<cfg>]
 # runner = "..."            # wrapper to run executables


### PR DESCRIPTION
Removes the temporary rust-lld linker override for the x86_64-pc-windows-msvc target from bk/crates/.cargo/config.toml, as rust issue #141626 has been fixed.

---
*PR created automatically by Jules for task [18108000146263443265](https://jules.google.com/task/18108000146263443265) started by @john-cd*