### PR TITLE
Fix GHA caching by splitting docker buildx bake into --push and --load steps

### DIFF
--- a/.github/workflows/build_deploy_book.yml
+++ b/.github/workflows/build_deploy_book.yml
@@ -81,9 +81,12 @@ jobs:
       # - name: Display the workspace (debug)
       #   run: echo ${{ github.workspace }}
       ## Build and push using the CLI
-      - name: Build, load to local image store, push to DockerHub
-        run: docker buildx bake -f compose.yaml -f compose-ci.yaml --push --load --allow=fs.read=.. --builder=${{ steps.builder.outputs.name }}
+      - name: Build, cache, and push to DockerHub
+        run: docker buildx bake -f compose.yaml -f compose-ci.yaml --push --allow=fs.read=.. --builder=${{ steps.builder.outputs.name }}
         # Will read the .env file there:
+        working-directory: ./.devcontainer/
+      - name: Load image to local Docker daemon
+        run: docker buildx bake -f compose.yaml -f compose-ci.yaml --load --set "*.cache-to=" --allow=fs.read=.. --builder=${{ steps.builder.outputs.name }}
         working-directory: ./.devcontainer/
       # - name: List docker images (debug)
       #   run: docker image ls


### PR DESCRIPTION
When both `--push` and `--load` are passed to `docker buildx bake` in a single command, Docker disables the cache export (`cache-to`) because the local Docker output format does not support cache exports (or it causes a conflict with multiple output types).

This commit resolves issue #1271 ("make gha caching work in CI workflow") by splitting the build command into two parts:
1. `docker buildx bake --push`: Builds the image, outputs to registry, and successfully exports cache to GitHub Actions Cache API (`type=gha`).
2. `docker buildx bake --load`: Re-runs the build, natively leveraging the existing cache generated by the previous step, and efficiently loads the image into the local Docker daemon for the subsequent `docker compose run` test step.

In the second step, `--set "*.cache-to="` is used to suppress any warnings about cache export failures.

---
*PR created automatically by Jules for task [15167170615681062491](https://jules.google.com/task/15167170615681062491) started by @john-cd*