### PR TITLE
Fix `dewikilink.sh` to correctly handle `[[...]]` links without titles

### DIFF
--- a/bk/scripts/wikilinks/dewikilink.sh
+++ b/bk/scripts/wikilinks/dewikilink.sh
@@ -13,13 +13,11 @@ root="$(realpath $1)/"
 files=$(find ${root}src -type f \( -name "*.md" -not -name "SUMMARY.md" -not -name "examples_index.md" -not -name "*.incl.md" \))
 
 # [[...]] or [[...|...]]
-regex='\[\[(\S+)\s*(\|\s*(.+))?\]\]'
+regex='\[\[([^|[:space:]\]]+)\s*(?:\|\s*([^]]+))?\]\]'
 
 for file in ${files}
 do
   echo -e ">> ${file}"
-  ## Replace [[...]] or [[...|...]] by [...][p~...]
-  sed -E -i "s=${regex}=[\3][p~\1]=g" "${file}" # -n p
 
   dir=$(dirname ${file})
   for target_file_name in $( rg --no-line-number --no-filename --only-matching -r '$1' "${regex}" "${file}" )
@@ -33,4 +31,8 @@ do
     rel_path=$(realpath --relative-to=${dir} ${target_path})
     echo "[p~${base}]: ${rel_path}" #>> "${dir}/refs.incl.md"
   done
+
+  ## Replace [[...|...]] by [...][p~...] and [[...]] by [...][p~...]
+  sed -E -i -e 's=\[\[([^]|[:space:]]+)\s*\|\s*([^]]+)\]\]=[\2][p~\1]=g' -e 's=\[\[([^]|[:space:]]+)\]\]=[\1][p~\1]=g' "${file}" # -n p
+
 done


### PR DESCRIPTION
Fixes the `dewikilink.sh` script to properly handle links without titles `[[target]]`, avoiding the issue where it generated `[][p~target]`.

- Moved the `sed` substitution to the end of the script loop. This fixes a critical bug where `sed` was modifying the file and replacing all links *before* `rg` could read them, completely breaking reference extraction.
- Updated the regex used by `sed` and `rg` to `\[\[([^|[:space:]\]]+)\s*(?:\|\s*([^]]+))?\]\]` to ensure we stop matching accurately before the pipe `|` and `]` characters.
- Separated `sed` logic to handle titled and untitled links explicitly.
Fixes #1244

---
*PR created automatically by Jules for task [15794793611023062827](https://jules.google.com/task/15794793611023062827) started by @john-cd*