### PR TITLE
fix: resolve review task in documentation_generation.md

### DIFF
--- a/bk/scripts/spelling/dictionary.txt
+++ b/bk/scripts/spelling/dictionary.txt
@@ -2631,7 +2631,6 @@ lldb
 llogiq
 llvm
 lmdb
-locahost
 localhost
 loco
 lodepng

--- a/bk/src/appendices/contributing/documentation_generation.md
+++ b/bk/src/appendices/contributing/documentation_generation.md
@@ -2,7 +2,7 @@
 
 {{#include documentation_generation.incl.md}}
 
-Use `just docs docall` to generate the code [[documentation]] in the [`docs.rs`][docs.rs~website]↗{{hi:docs.rs}}{{hi:docs.rs}} format.
+Use `just docs docall` to generate the code [[documentation]] in the [`docs.rs`][docs.rs~website]↗{{hi:docs.rs}} format.
 
 Note that [`cargo doc --open`][book~cargo~cargo-doc]↗{{hi:cargo doc}} does not seem to work when running from a Dev Container{{hi:Dev Container}} in VS Code{{hi:VS Code}}; the script that opens URLs into an external browser (see `$ echo $BROWSER`) does not handle raw HTML. Use `python3 -m http.server 9000` (or live server) to serve the files instead.
 
@@ -43,7 +43,7 @@ xdg-settings --list
 xdg-settings get default-web-browser
 ```
 
-Point your browser to [http://localhost:6080][locahost:6080~website]↗ and use [`vscode`][vscode~website]↗{{hi:VS Code}} as the password. Open the HTML file of your choice with:
+Point your browser to [http://localhost:6080][localhost:6080~website]↗ and use [`vscode`][vscode~website]↗{{hi:VS Code}} as the password. Open the HTML file of your choice with:
 
 ```bash
 xdg-open /code/target/bk/doc/deps/index.html
@@ -62,7 +62,3 @@ xdg-open /code/target/bk/doc/deps/index.html
 
 {{#include refs.incl.md}}
 {{#include ../../refs/link-refs.md}}
-
-<div class="hidden">
-[review](https://github.com/john-cd/rust_howto/issues/980)
-</div>

--- a/bk/src/refs/other-refs.md
+++ b/bk/src/refs/other-refs.md
@@ -1108,7 +1108,7 @@
 [linkerd~website]: https://linkerd.io
 [lld~website]: https://lld.llvm.org
 [lld~website~badge]: https://img.shields.io/badge/lld-coral
-[locahost:6080~website]: http://localhost:6080
+[localhost:6080~website]: http://localhost:6080
 [localhost:3000]: http://localhost:3000
 [logstash~website]: https://elastic.co/logstash
 [lord.io~website]: https://lord.io


### PR DESCRIPTION
Resolves the review task in `bk/src/appendices/contributing/documentation_generation.md`. Fixes the `localhost` typo globally, removes duplicated docs.rs format snippet, drops the hidden div, and cleans up the spelling dictionary accordingly.

---
*PR created automatically by Jules for task [15346985044875335098](https://jules.google.com/task/15346985044875335098) started by @john-cd*