### PR TITLE
docs: Update OpenSSL winget install command

### DIFF
--- a/bk/src/appendices/contributing/development_environment_setup.md
+++ b/bk/src/appendices/contributing/development_environment_setup.md
@@ -45,7 +45,7 @@ winget install Microsoft.VisualStudioCode
 winget install Docker.DockerDesktop
 winget install Casey.Just
 winget install Python.Python.3
-winget install ShiningLight.OpenSSL  # Required by crates that depend on native TLS (e.g. `openssl-sys`)
+winget install openssl  # Required by crates that depend on native TLS (e.g. `openssl-sys`)
 ```
 
 After installing Rust via `rustup`, open a new terminal and run:
@@ -84,17 +84,11 @@ apt-get -y install just
 
 ## Related Topics {#related-topics .skip}
 
-- [[rust-installation | Rust Installation]].
-
-{{#include refs.incl.md}}
-{{#include ../../refs/link-refs.md}}
-
-<div class="hidden">
-[dev_environment_setup: review; write windows install; `winget install openssl`; need Python](https://github.com/john-cd/rust_howto/issues/527)
-
 - [[containers | Containers]].
 - [[development_tools | Development Tools]].
+- [[rust-installation | Rust Installation]].
 - [[text-editors | Text Editors]].
 - [[vscode | Vscode]].
 
-</div>
+{{#include refs.incl.md}}
+{{#include ../../refs/link-refs.md}}


### PR DESCRIPTION
Updates the `winget` installation command for OpenSSL in the Windows development setup guide, matching the requested format. It verifies that Python is already correctly specified in the commands. It also tidies up the document by extracting related topic links from a hidden block and sorting them into the visible "Related Topics" section, completely removing the obsolete hidden issue description.

---
*PR created automatically by Jules for task [11274811937104956607](https://jules.google.com/task/11274811937104956607) started by @john-cd*