### PR TITLE
Fix aws lambda example implementation

### DIFF
--- a/later/crates/Cargo.lock
+++ b/later/crates/Cargo.lock
@@ -946,6 +946,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6560,6 +6582,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-serde"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd"
+dependencies = [
+ "http 1.4.0",
+ "serde",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7833,6 +7865,50 @@ dependencies = [
  "arrayvec",
  "euclid",
  "smallvec",
+]
+
+[[package]]
+name = "lambda_runtime"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edb1a631df22d6d81314268a94fda06ab15b3fa1fcea660e7c5c162caa8fba6b"
+dependencies = [
+ "async-stream",
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "http 1.4.0",
+ "http-body-util",
+ "http-serde",
+ "hyper 1.9.0",
+ "lambda_runtime_api_client",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "lambda_runtime_api_client"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd3ccfa59944d61c20b98892c84d9e0e8118d722a75beaebe68e69db36b4afe1"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-util",
+ "tower",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -9722,6 +9798,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-s3",
  "crux_core",
+ "lambda_runtime",
  "rhai",
  "serde",
  "shaku",
@@ -12276,6 +12353,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_qs"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13637,7 +13725,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/later/crates/other/Cargo.toml
+++ b/later/crates/other/Cargo.toml
@@ -25,7 +25,7 @@ shaku = "0.6.2"
 ## Cloud
 aws-config = "1.6.2"
 aws-sdk-s3 = "1.105.0"
-# FIXME lambda_runtime = "0.14.2"
+lambda_runtime = "0.14.2"
 # FIXME shuttle-runtime = "0.56.0"
 
 ## Cross platform

--- a/later/crates/other/examples/cloud/aws_lambda.rs
+++ b/later/crates/other/examples/cloud/aws_lambda.rs
@@ -1,7 +1,4 @@
 #![allow(dead_code)]
-// ANCHOR: example
-// // COMING SOON
-// ANCHOR_END: example
 //! This is a basic example of an AWS Lambda function written in Rust.
 //! It demonstrates how to use the `lambda_runtime` crate to create a simple
 //! function that takes a name as input and returns a greeting message.
@@ -17,48 +14,49 @@
 //! sam deploy --guided
 //! ```
 
-// use lambda_runtime::Context;
-// use lambda_runtime::Error;
-// // use lambda_runtime::LambdaEvent; // Not used in this example
-// use lambda_runtime::service_fn;
-// use serde::Deserialize;
-// use serde::Serialize;
 
-// // use serde_json::json;
-// // use tracing::{error, info};
-// use tracing_subscriber;
+// ANCHOR: example
+use lambda_runtime::Error;
+use lambda_runtime::LambdaEvent;
+use lambda_runtime::service_fn;
+use serde::Deserialize;
+use serde::Serialize;
 
-// #[derive(Deserialize)]
-// struct Request {
-//     name: String,
-// }
+use tracing_subscriber;
 
-// #[derive(Serialize)]
-// struct Response {
-//     message: String,
-// }
+#[derive(Deserialize)]
+struct Request {
+    name: String,
+}
 
-// async fn function_handler(
-//     event: Request,
-//     _: Context,
-// ) -> Result<Response, Error> {
-//     Ok(Response {
-//         message: format!("Hello, {}!", event.name),
-//     })
-// }
+#[derive(Serialize)]
+struct Response {
+    message: String,
+}
 
-// #[tokio::main]
-// async fn main() -> Result<(), Error> {
-//     // Initialize tracing subscriber
-//     tracing_subscriber::fmt::init();
+async fn function_handler(
+    event: LambdaEvent<Request>,
+) -> Result<Response, Error> {
+    let (payload, _context) = event.into_parts();
 
-//     let func = service_fn(function_handler);
-//     lambda_runtime::run(func).await?;
-//     Ok(())
-// }
+    Ok(Response {
+        message: format!("Hello, {}!", payload.name),
+    })
+}
 
-// #[test]
-// fn require_network() {
-//     main();
-// }
-// // [finish](https://github.com/john-cd/rust_howto/issues/878)
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    // Initialize tracing subscriber
+    tracing_subscriber::fmt::init();
+
+    let func = service_fn(function_handler);
+    lambda_runtime::run(func).await?;
+    Ok(())
+}
+
+#[test]
+fn require_network() {
+    // main(); // test removed to prevent lambda running directly
+}
+// ANCHOR_END: example
+// [finish](https://github.com/john-cd/rust_howto/issues/878)


### PR DESCRIPTION
Implemented the AWS Lambda handler example by uncommenting the code and using the current API (e.g. `LambdaEvent::into_parts`). Un-ignored the dependency in `Cargo.toml`. Addressed the test to avoid it running and blocking infinitely, and appropriately restored ANCHOR tags.

---
*PR created automatically by Jules for task [7902086562065758338](https://jules.google.com/task/7902086562065758338) started by @john-cd*