### PR TITLE
Fix algorithm index and add A* graph example

### DIFF
--- a/bk/crates/cats/algorithms/examples/graph/main.rs
+++ b/bk/crates/cats/algorithms/examples/graph/main.rs
@@ -1,3 +1,4 @@
+mod petgraph_astar;
 mod petgraph_bfs;
 mod petgraph_dfs;
 mod petgraph_dijkstra;

--- a/bk/crates/cats/algorithms/examples/graph/petgraph_astar.rs
+++ b/bk/crates/cats/algorithms/examples/graph/petgraph_astar.rs
@@ -1,0 +1,44 @@
+#![allow(dead_code)]
+// ANCHOR: example
+use petgraph::Graph;
+use petgraph::algo::astar;
+
+/// Demonstrates A* shortest path algorithm using `petgraph`.
+fn main() {
+    let mut graph = Graph::<(i32, i32), u32>::new();
+
+    let a = graph.add_node((0, 0));
+    let b = graph.add_node((1, 0));
+    let c = graph.add_node((2, 0));
+    let d = graph.add_node((1, 1));
+    let e = graph.add_node((2, 1));
+
+    graph.add_edge(a, b, 1);
+    graph.add_edge(b, c, 1);
+    graph.add_edge(a, d, 2);
+    graph.add_edge(d, e, 1);
+    graph.add_edge(c, e, 1);
+
+    let path = astar(&graph, a, |finish| finish == e, |e| *e.weight(), |node| {
+        let (x, y) = graph[node];
+        let (ex, ey) = graph[e];
+        (x.abs_diff(ex) + y.abs_diff(ey)) as u32
+    });
+
+    println!("Shortest path from A to E:");
+    if let Some((cost, path_nodes)) = path {
+        println!("  Cost: {}", cost);
+        for node in path_nodes {
+            println!("  Node: {:?}", graph[node]);
+        }
+        assert_eq!(cost, 3);
+    } else {
+        println!("No path found.");
+    }
+}
+// ANCHOR_END: example
+
+#[test]
+fn test() {
+    main();
+}

--- a/bk/src/categories/algorithms/graph_algorithms.incl.md
+++ b/bk/src/categories/algorithms/graph_algorithms.incl.md
@@ -4,3 +4,4 @@
 | [Traverse a Graph with Depth-First Search (DFS)][ex~algorithms~petgraph-dfs] | [![petgraph][c~petgraph~docs~badge]][c~petgraph~docs] | [![cat~algorithms][cat~algorithms~badge]][cat~algorithms] |
 | [Find Shortest Paths with Dijkstra's Algorithm][ex~algorithms~petgraph-dijkstra] | [![petgraph][c~petgraph~docs~badge]][c~petgraph~docs] | [![cat~algorithms][cat~algorithms~badge]][cat~algorithms] |
 | [Sort Tasks Topologically in a DAG][ex~algorithms~petgraph-toposort] | [![petgraph][c~petgraph~docs~badge]][c~petgraph~docs] | [![cat~algorithms][cat~algorithms~badge]][cat~algorithms] |
+| [Find Shortest Paths with A* Search][ex~algorithms~petgraph-astar] | [![petgraph][c~petgraph~docs~badge]][c~petgraph~docs] | [![cat~algorithms][cat~algorithms~badge]][cat~algorithms] |

--- a/bk/src/categories/algorithms/graph_algorithms.md
+++ b/bk/src/categories/algorithms/graph_algorithms.md
@@ -46,6 +46,16 @@ Topological sort{{hi:Topological sort}} produces a linear ordering of the nodes 
 {{#include ../../../crates/cats/algorithms/examples/graph/petgraph_toposort.rs:example}}
 ```
 
+## Find Shortest Paths with A* Search {#petgraph-astar}
+
+[![petgraph][c~petgraph~docs~badge]][c~petgraph~docs] [![petgraph~crates.io][c~petgraph~crates.io~badge]][c~petgraph~crates.io] [![petgraph~repo][c~petgraph~repo~badge]][c~petgraph~repo] [![petgraph~lib.rs][c~petgraph~lib.rs~badge]][c~petgraph~lib.rs]{{hi:petgraph}}{{hi:A* Search}}{{hi:Shortest path}} [![cat~algorithms][cat~algorithms~badge]][cat~algorithms]{{hi:Algorithms}}
+
+A* Search{{hi:A* Search}} is a pathfinding algorithm that computes the shortest path by utilizing a heuristic to guide the search towards the target.
+
+```rust,editable,noplayground
+{{#include ../../../crates/cats/algorithms/examples/graph/petgraph_astar.rs:example}}
+```
+
 ## See Also {#see-also .skip}
 
 - [`pathfinding`][c~pathfinding~docs]↗{{hi:pathfinding}} provides pathfinding algorithms including A*, Dijkstra, BFS, DFS, and more.

--- a/bk/src/categories/algorithms/index.md
+++ b/bk/src/categories/algorithms/index.md
@@ -37,6 +37,8 @@ For [[compression | compression]], use:
 - `snap` for Snappy compression.
 - `brotli` for Brotli compression.
 
+
+See [[compression | Compression]].
 ### Data Structures
 
 For common [[data-structures | data structures]] ([`Vec`][c~std::vec::Vec~docs]↗, [`HashMap`][c~std::collections::HashMap~docs]↗, etc.), you will use [`std::collections`][c~std::collections~docs]↗. You may also consider:
@@ -53,6 +55,8 @@ Worth a mention: `fst` provides fast, memory-efficient, immutable set and map da
 
 See [[vector | vector]] [[hashmap | hash maps]], [[maps | other maps]], [[binaryheap | Binary Heap]] within the [[data-structures | Data Structures]] section for more details.
 
+
+See [[data-structures | Data Structures]] and [[concurrent_data_structures | Concurrent Data Structures]].
 ### Recursive Algorithms
 
 - `stacker` is a stack growth library useful when implementing deeply recursive algorithms that may accidentally blow the stack.
@@ -68,7 +72,7 @@ For small-scale tasks, like filtering a list of items in memory, reach first for
 - `argminmax` provides efficient argmin & argmax (in 1 function) with SIMD for floats and integers.
 - `bytecount` count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast.
 
-[meilisearch][c~meilisearch~repo]↗ and [tantivy][c~tantivy~repo]↗ are full-text search engines written in Rust, similar to what you'd expect from `Elasticsearch` or `Algolia`.
+[meilisearch][c~meilisearch~repo]↗ and [tantivy][c~tantivy~repo]↗ are full-text search engines written in Rust, similar to what you'd expect from `Elasticsearch` or `Algolia`. See also [[rust_search_engines | Search Engines]].
 
 ### String Algorithms and Text Processing
 
@@ -80,6 +84,15 @@ For [[strings | Strings]], use:
 - [`strsim`][c~strsim~docs]↗{{hi:strsim}} for string similarity.
 
 See also [[string_concat | String Concat]], [[string_encoding | String Encoding]], [[string_parsing | String Parsing]], and [[text-processing | Text Processing]].
+
+### Cryptography
+
+See [[cryptography | Cryptography]], [[cryptography_utilities | Cryptography Utilities]], and [[encryption | Encryption]].
+
+### Data Processing
+
+See [[data-processing | Data Processing]].
+
 
 ### Numerical and Mathematical Algorithms
 
@@ -105,6 +118,11 @@ For [[mathematics | Mathematics]], use the following crates for general numerica
   - `rustfft` for Fast Fourier Transforms.
   - `roots` for numerical root finding.
 
+### Science
+
+See [[science | Science]], [[_machine_learning | Machine Learning]], [[science_geo | Geoscience]], [[science_neuroscience | Neuroscience]], [[science_robotics | Science Robotics]], and [[simulation | Simulation]].
+
+
 ## References
 
 - [`rust-algorithms`][rust-algorithms~repo]↗: Common data structures and algorithms in Rust.
@@ -112,21 +130,3 @@ For [[mathematics | Mathematics]], use the following crates for general numerica
 {{#include refs.incl.md}}
 {{#include ../../refs/link-refs.md}}
 
-<div class="hidden">
-[review](https://github.com/john-cd/rust_howto/issues/1165)
-
-review [rust-algorithms~repo][rust-algorithms~repo].
-
-| Topic | Related Links |
-|---|---|
-| [[compression | Compression]] | |
-| [[cryptography | Cryptography]] | [[cryptography_utilities | Cryptography Utilities]], [[encryption | Encryption]] |
-| [[data-processing | Data Processing]] | |
-| [[data-structures | Data Structures]] | [[concurrent_data_structures | Concurrent Data Structures]] |
-| [[science | Science]] | [[_machine_learning | Machine Learning]], [[science_geo | Geoscience]], [[science_neuroscience | Neuroscience]], [[science_robotics | Science Robotics]], [[simulation | Simulation]] |
-| [[search | Search]] | [[rust_search_engines | Search Engines]] |
-| [[strings | Strings]] | [[string_concat | String Concat]], [[string_encoding | String Encoding]], [[string_parsing | String Parsing]], [[text-processing | Text Processing]] |
-
-See [[rust_search_engines | Search Engines]].
-
-</div>


### PR DESCRIPTION
This pull request completes the transition of `algorithms/index.md` from a draft to a publishable state as described in issue #1165. 

Changes include:
- Removing the hidden draft `<div class="hidden">` element containing pending TODO topics.
- Incorporating missing topic cross-links (`Cryptography`, `Data Processing`, `Science`, `Search Engines`, `Compression`, `Data Structures`) into the document appropriately.
- Adding a new `petgraph` based `A* Search` graphing algorithm example to fulfill the "add graph examples" mandate, along with test configuration.

---
*PR created automatically by Jules for task [13097836672367948616](https://jules.google.com/task/13097836672367948616) started by @john-cd*