### PR TITLE
docs(aerospace): review #190

### DIFF
--- a/later/src/categories/aerospace/index.md
+++ b/later/src/categories/aerospace/index.md
@@ -6,6 +6,27 @@
 
 {{#include aerospace.incl.md}}
 
+## Drones
+
+See [[aerospace_drones | Drones]].
+
+## Protocols
+
+See [[aerospace_protocols | Aerospace Protocols]].
+
+## Simulation
+
+See [[aerospace_simulation | Aerospace Simulation]].
+
+## Space Protocols
+
+See [[aerospace_space-protocols | Space Protocols]].
+
+## Unmanned Aerial Vehicles
+
+See [[aerospace_unmanned-aerial-vehicles | Unmanned Aerial Vehicles]].
+
+
 ## Related Topics
 
 ### Code Verification
@@ -54,6 +75,3 @@ See [[testing | Testing]].
 {{#include refs.incl.md}}
 {{#include ../../refs/link-refs.md}}
 
-<div class="hidden">
-[review](https://github.com/john-cd/rust_howto/issues/190)
-</div>


### PR DESCRIPTION
Added markdown links to subcategories in `aerospace/index.md` matching the multimedia category style and removed the hidden review div containing `[review](https://github.com/john-cd/rust_howto/issues/190)`.

---
*PR created automatically by Jules for task [16700339329932585912](https://jules.google.com/task/16700339329932585912) started by @john-cd*