### PR TITLE
feat: complete aerospace_protocols chapter using mavlink crate

### DIFF
--- a/later/crates/Cargo.lock
+++ b/later/crates/Cargo.lock
@@ -138,6 +138,9 @@ version = "0.1.2"
 [[package]]
 name = "aerospace_protocols"
 version = "0.1.2"
+dependencies = [
+ "mavlink",
+]
 
 [[package]]
 name = "aerospace_simulation"
@@ -3141,6 +3144,12 @@ checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
 dependencies = [
  "crc-catalog",
 ]
+
+[[package]]
+name = "crc-any"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a62ec9ff5f7965e4d7280bd5482acd20aadb50d632cf6c1d74493856b011fa73"
 
 [[package]]
 name = "crc-catalog"
@@ -7500,6 +7509,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-kit-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617ee6cf8e3f66f3b4ea67a4058564628cde41901316e19f559e14c7c72c5e7b"
+dependencies = [
+ "core-foundation-sys",
+ "mach2",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8455,6 +8474,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "mavlink"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0df4c9e6c5f14b13459638df2dd35efdc4743b327621d5bfe7801bb850326f44"
+dependencies = [
+ "bitflags 2.11.1",
+ "mavlink-bindgen",
+ "mavlink-core",
+ "num-derive",
+ "num-traits",
+ "serde",
+ "serde_arrays",
+]
+
+[[package]]
+name = "mavlink-bindgen"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2052217619766a23bd0181e7ddee6c4661fac7e5179f75c8f802fec551278304"
+dependencies = [
+ "crc-any",
+ "proc-macro2",
+ "quick-xml 0.39.2",
+ "quote",
+ "regex",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "mavlink-core"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e8f00fd8c85980548571d28ead126f320733bbe27684aa02f1787060d3264d"
+dependencies = [
+ "byteorder",
+ "crc-any",
+ "serde",
+ "serde_arrays",
+ "serialport",
+]
+
+[[package]]
 name = "maybe-rayon"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8889,6 +8950,17 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "nix"
@@ -12232,6 +12304,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_arrays"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94a16b99c5ea4fe3daccd14853ad260ec00ea043b2708d1fd1da3106dcd8d9df"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12391,6 +12472,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serialport"
+version = "4.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4d91116f97173694f1642263b2ff837f80d933aa837e2314969f6728f661df3"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "io-kit-sys",
+ "mach2",
+ "nix 0.26.4",
+ "scopeguard",
+ "unescaper",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13637,7 +13736,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -14473,6 +14572,15 @@ checksum = "61de84ebdb9c2e756d18fcd378802b5a0d359863fcee3ced54ac2d2fbb19cf74"
 dependencies = [
  "ui-events",
  "winit",
+]
+
+[[package]]
+name = "unescaper"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4064ed685c487dbc25bd3f0e9548f2e34bab9d18cefc700f9ec2dba74ba1138e"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/later/crates/cats/aerospace_protocols/Cargo.toml
+++ b/later/crates/cats/aerospace_protocols/Cargo.toml
@@ -15,7 +15,5 @@ publish.workspace = true
 autolib = false
 
 [dependencies]
+mavlink = "0.17.1"
 
-## General
-# FIXME
-#anyhow = "1.0.95"

--- a/later/crates/cats/aerospace_protocols/examples/aerospace_protocols/aero_protocols.rs
+++ b/later/crates/cats/aerospace_protocols/examples/aerospace_protocols/aero_protocols.rs
@@ -1,12 +1,35 @@
-#![allow(dead_code)]
-// // ANCHOR: example
-// // COMING SOON
-// // ANCHOR_END: example
-// fn main() {}
+use mavlink::common;
 
-// #[test]
-// #[ignore = "later"]
-// fn test() {
-//     main();
-// }
-// // [write LATER](https://github.com/john-cd/rust_howto/issues/62)
+// ANCHOR: example
+pub fn main() {
+    // Create a new heartbeat message using the `common` dialect
+    let heartbeat = common::HEARTBEAT_DATA {
+        custom_mode: 0,
+        mavtype: common::MavType::MAV_TYPE_QUADROTOR,
+        autopilot: common::MavAutopilot::MAV_AUTOPILOT_ARDUPILOTMEGA,
+        base_mode: common::MavModeFlag::MAV_MODE_FLAG_SAFETY_ARMED,
+        system_status: common::MavState::MAV_STATE_STANDBY,
+        mavlink_version: 3,
+    };
+
+    // Create a generic message from the heartbeat data
+    let message = common::MavMessage::HEARTBEAT(heartbeat);
+
+    // In a real application, you would send this message over a connection:
+    // let mut conn = mavlink::connect("udpin:0.0.0.0:14550").unwrap();
+    // let header = mavlink::MavHeader {
+    //     system_id: 1,
+    //     component_id: 1,
+    //     sequence: 0,
+    // };
+    // conn.send(&header, &message).unwrap();
+
+    // Verify the message type
+    assert!(matches!(message, common::MavMessage::HEARTBEAT(_)));
+}
+// ANCHOR_END: example
+
+#[test]
+fn test() {
+    main();
+}

--- a/later/crates/cats/aerospace_protocols/examples/aerospace_protocols/main.rs
+++ b/later/crates/cats/aerospace_protocols/examples/aerospace_protocols/main.rs
@@ -1,5 +1,5 @@
 mod aero_protocols;
 
 fn main() {
-    // aero_protocols::main();
+    aero_protocols::main();
 }

--- a/later/src/categories/aerospace_protocols/aerospace_protocols.incl.md
+++ b/later/src/categories/aerospace_protocols/aerospace_protocols.incl.md
@@ -1,3 +1,3 @@
 | Recipe | Crates | Categories |
 |---|---|---|
-| [Aerospace Protocols][ex~aerospace_protocols~aerospace_protocols] | {{!crate }} | [![cat~aerospace::protocols][cat~aerospace::protocols~badge]][cat~aerospace::protocols] |
+| [Aerospace Protocols][ex~aerospace_protocols~aerospace_protocols] | {{!crate mavlink}} | [![cat~aerospace::protocols][cat~aerospace::protocols~badge]][cat~aerospace::protocols] |

--- a/later/src/categories/aerospace_protocols/aerospace_protocols.md
+++ b/later/src/categories/aerospace_protocols/aerospace_protocols.md
@@ -17,6 +17,3 @@
 {{#include refs.incl.md}}
 {{#include ../../refs/link-refs.md}}
 
-<div class="hidden">
-[protocols: write](https://github.com/john-cd/rust_howto/issues/195)
-</div>


### PR DESCRIPTION
- Added `mavlink` dependency to `later/crates/cats/aerospace_protocols/Cargo.toml`
- Implemented a heartbeat message example in `aero_protocols.rs` demonstrating how to create and construct standard messages
- Updated the markdown template `aerospace_protocols.incl.md` with the specific crate name to render correct badges
- Removed hidden placeholders and FIXME items from `aerospace_protocols.md`

Fixes #195

---
*PR created automatically by Jules for task [9499757240980202355](https://jules.google.com/task/9499757240980202355) started by @john-cd*