### PR TITLE
docs: finalize aerospace_unmanned-aerial-vehicles markdown

### DIFF
--- a/later/src/categories/aerospace_unmanned-aerial-vehicles/index.md
+++ b/later/src/categories/aerospace_unmanned-aerial-vehicles/index.md
@@ -18,40 +18,33 @@ Consider using:
 - Spektrum DSM/DSMX: Another common RC protocol.
 - FrSky SmartPort/FPort: A telemetry protocol used by FrSky RC systems.
 
-## Related Topics
-
-### Parsing Binary Data
+## Parsing Binary Data
 
 Consider using crates like [`nom`][c~nom~docs]↗{{hi:nom}} or [`binascii`][c~binascii~docs]↗{{hi:binascii}}.
 
-See [[parsing | Parsing]] and [[_binary_encoders |  Binary Encoders]].
+See [[parsing | Parsing]] and [[_binary_encoders | Binary Encoders]].
 
-### Data Structures and Serialization
+## Data Structures and Serialization
 
 Define Rust structs to represent the message formats of the protocols. [`serde`][c~serde~docs]↗{{hi:serde}} can be used for serialization/deserialization.
 
 See [[data-structures | Data Structures]] and [[encoding | Encoding]].
 
-### FFI (Foreign Function Interface)
+## FFI (Foreign Function Interface)
 
 If existing C/C++ libraries are available, FFI can be a viable option, but it adds complexity.
 
-See:
+See [[development-tools_ffi | Development Tools: FFI]], [[external-ffi-bindings | External FFI Bindings]], and [[generate_ffi_bindings | Generate FFI Bindings]].
 
-- [[development-tools_ffi | FFI]].
-- [[external-ffi-bindings | External FFI Bindings]].
-- [[external_ffi_bindings | External FFI Bindings]].
-- [[generate_ffi_bindings | Generate FFI Bindings]].
-
-### `#![no_std]` (for Embedded systems)
+## `#![no_std]` (for Embedded systems)
 
 If your target is a flight controller running on an embedded system, [`#![no_std]`][book~rust-reference~no_std]↗{{hi:no_std}} is essential.
 
 See [[no_std | No Std]] and [[no_alloc | No Alloc]].
 
+## Related Topics
+
+- [[aerospace | Aerospace]].
+
 {{#include refs.incl.md}}
 {{#include ../../refs/link-refs.md}}
-
-<div class="hidden">
-[aerospace_unmanned-aerial-vehicles: write](https://github.com/john-cd/rust_howto/issues/205)
-</div>

--- a/later/src/categories/aerospace_unmanned-aerial-vehicles/uavs.md
+++ b/later/src/categories/aerospace_unmanned-aerial-vehicles/uavs.md
@@ -14,7 +14,3 @@
 
 {{#include refs.incl.md}}
 {{#include ../../refs/link-refs.md}}
-
-<div class="hidden">
-[uavs: write](https://github.com/john-cd/rust_howto/issues/204)
-</div>


### PR DESCRIPTION
Cleaned up `later/src/categories/aerospace_unmanned-aerial-vehicles/index.md` and `uavs.md` by:
- Removing `<div class="hidden">` issue tracking blocks.
- Fixing wikilink formatting to standard `[[target | title]]` or simplified syntax.
- Adjusting nested heading levels (`###` -> `##`) for correct hierarchy layout.

---
*PR created automatically by Jules for task [6200970014598657578](https://jules.google.com/task/6200970014598657578) started by @john-cd*