### PR TITLE
doc: write chapter aerospace_space-protocols and add spacepackets example

### DIFF
--- a/later/crates/Cargo.lock
+++ b/later/crates/Cargo.lock
@@ -146,6 +146,10 @@ version = "0.1.2"
 [[package]]
 name = "aerospace_space_protocols"
 version = "0.1.2"
+dependencies = [
+ "arbitrary-int 2.1.1",
+ "spacepackets",
+]
 
 [[package]]
 name = "aerospace_unmanned_aerial_vehicles"
@@ -373,6 +377,18 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
+name = "arbitrary-int"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "825297538d77367557b912770ca3083f778a196054b3ee63b22673c4a3cae0a5"
+
+[[package]]
+name = "arbitrary-int"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993a810118f8f37e9c4411c86f1c4c940a09a7ab34b7bf2d88d06f50c553fab7"
 
 [[package]]
 name = "arboard"
@@ -1728,6 +1744,18 @@ name = "bit_field"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
+name = "bitbybit"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec187a89ab07e209270175faf9e07ceb2755d984954e58a2296e325ddece2762"
+dependencies = [
+ "arbitrary-int 1.3.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "bitflags"
@@ -3517,6 +3545,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "uuid",
+]
+
+[[package]]
+name = "defmt"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "548d977b6da32fa1d1fda2876453da1e7df63ad0304c8b3dae4dbe7b96f39b78"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d4fc12a85bcf441cfe44344c4b72d58493178ce635338a3f3b78943aceb258e"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "delegate"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12989,6 +13060,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "spacepackets"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94979a990b4333f43667cba9fe9e72b9c4e9ada82e09fbe8fb250844358590cc"
+dependencies = [
+ "arbitrary-int 2.1.1",
+ "bitbybit",
+ "chrono",
+ "crc",
+ "defmt",
+ "delegate",
+ "num-traits",
+ "num_enum",
+ "paste",
+ "serde",
+ "thiserror 2.0.18",
+ "zerocopy",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13637,7 +13728,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/later/crates/cats/aerospace_space_protocols/Cargo.toml
+++ b/later/crates/cats/aerospace_space_protocols/Cargo.toml
@@ -15,7 +15,6 @@ publish.workspace = true
 autolib = false
 
 [dependencies]
+arbitrary-int = "2.1.1"
+spacepackets = "0.17"
 
-## General
-# FIXME
-#anyhow = "1.0.95"

--- a/later/crates/cats/aerospace_space_protocols/examples/space_protocols/space_protocols.rs
+++ b/later/crates/cats/aerospace_space_protocols/examples/space_protocols/space_protocols.rs
@@ -1,12 +1,25 @@
 #![allow(dead_code)]
-// // ANCHOR: example
-// // COMING SOON
-// // ANCHOR_END: example
-// fn main() {}
+// ANCHOR: example
+use arbitrary_int::u11;
+use arbitrary_int::u14;
+use spacepackets::CcsdsPacket;
+use spacepackets::SequenceFlags;
+use spacepackets::SpHeader;
 
-// #[test]
-// #[ignore = "later"]
-// fn test() {
-//     main();
-// }
-// // [write LATER](https://github.com/john-cd/rust_howto/issues/64)
+pub fn main() {
+    let header = SpHeader::new_for_tm(
+        u11::new(0x10),
+        SequenceFlags::Unsegmented,
+        u14::new(0x01),
+        3,
+    );
+
+    assert_eq!(header.apid().value(), 0x10);
+    assert_eq!(header.seq_count().value(), 0x01);
+}
+// ANCHOR_END: example
+
+#[test]
+fn test() {
+    main();
+}

--- a/later/src/categories/aerospace_space-protocols/index.md
+++ b/later/src/categories/aerospace_space-protocols/index.md
@@ -49,11 +49,9 @@ See [[encoding | Encoding]] and especially [[complex_encoding | Complex Encoding
 
 ## Related Topics
 
-FIXME
+- [[aerospace | Aerospace]].
+- [[aerospace_protocols | Aerospace Protocols]].
 
 {{#include refs.incl.md}}
 {{#include ../../refs/link-refs.md}}
 
-<div class="hidden">
-[write](https://github.com/john-cd/rust_howto/issues/202)
-</div>


### PR DESCRIPTION
Resolves issue by writing the content for the `aerospace_space-protocols` chapter.

- Fixed the `Related Topics` placeholders in `later/src/categories/aerospace_space-protocols/index.md` to point to correct wikilinks.
- Removed the hidden issue tracking div.
- Replaced the stubbed `// COMING SOON` Rust code example in `later/crates/cats/aerospace_space_protocols/examples/space_protocols/space_protocols.rs` with a complete, tested example demonstrating how to create a CCSDS space packet header using the `spacepackets` and `arbitrary-int` crates.
- Added `spacepackets` and `arbitrary-int` as dependencies to `aerospace_space_protocols` Cargo.toml.

---
*PR created automatically by Jules for task [17458826813550670169](https://jules.google.com/task/17458826813550670169) started by @john-cd*