### PR TITLE
Fix prost integration in encoding crate

### DIFF
--- a/bk/crates/cats/encoding/build.rs
+++ b/bk/crates/cats/encoding/build.rs
@@ -16,7 +16,7 @@ fn capnp() {
 fn prost() {
     prost_build::compile_protos(
         &["examples/binary_encoders/person.proto"],
-        &["src/"],
+        &["examples/binary_encoders/"],
     )
     .unwrap();
 }
@@ -25,6 +25,6 @@ fn prost() {
 fn main() {
     #[cfg(target_os = "linux")]
     capnp();
-    // prost();
+    prost();
 }
 // [fix prost](https://github.com/john-cd/rust_howto/issues/1417)

--- a/bk/crates/cats/encoding/examples/binary_encoders/prost.rs
+++ b/bk/crates/cats/encoding/examples/binary_encoders/prost.rs
@@ -1,38 +1,37 @@
 #![allow(dead_code)]
-// // ANCHOR: example
-// // COMING SOON
-// // ANCHOR_END: example
-// //! This example demonstrates how to use the `prost` crate to serialize and
-// //! deserialize a protobuf message.
-// //!
-// //! It defines a simple `Person` message, serializes it to a byte buffer,
-// //! and then deserializes it back into a `Person` struct.
-// use person::Person;
-// use prost::Message;
+// ANCHOR: example
+//! This example demonstrates how to use the `prost` crate to serialize and
+//! deserialize a protobuf message.
+//!
+//! It defines a simple `Person` message, serializes it to a byte buffer,
+//! and then deserializes it back into a `Person` struct.
+use person::Person;
+use prost::Message;
 
-// mod person {
-//     include!(concat!(env!("OUT_DIR"),
-// "/examples/binary_encoders/person.rs")); }
+mod person {
+    include!(concat!(env!("OUT_DIR"), "/example.rs"));
+}
 
-// fn main() {
-//     // Create a `Person` message.
-//     let person = Person {
-//         name: "Alice".to_string(),
-//         age: 30,
-//     };
+fn main() {
+    // Create a `Person` message.
+    let person = Person {
+        name: "Alice".to_string(),
+        age: 30,
+    };
 
-//     // Serialize the message.
-//     let mut buf = Vec::new();
-//     person.encode(&mut buf).unwrap();
+    // Serialize the message.
+    let mut buf = Vec::new();
+    person.encode(&mut buf).unwrap();
 
-//     // Deserialize the message.
-//     let decoded_person = Person::decode(&*buf).unwrap();
+    // Deserialize the message.
+    let decoded_person = Person::decode(&*buf).unwrap();
 
-//     println!("Name: {}, Age: {}", decoded_person.name, decoded_person.age);
-// }
+    println!("Name: {}, Age: {}", decoded_person.name, decoded_person.age);
+}
+// ANCHOR_END: example
 
-// #[test]
-// fn test() {
-//     main();
-// }
-// // [finish](https://github.com/john-cd/rust_howto/issues/1044)
+#[test]
+fn test() {
+    main();
+}
+// [finish](https://github.com/john-cd/rust_howto/issues/1044)


### PR DESCRIPTION
The prost integration in the `encoding` crate was broken and commented out. 
This PR:
1. Fixes the `build.rs` script to correctly locate the `.proto` files in `examples/binary_encoders/`.
2. Uncomments the `prost()` call in `build.rs` to enable Protobuf compilation.
3. Restores and fixes the `prost.rs` example by:
    - Removing the `COMING SOON` placeholder.
    - Updating the `include!` macro to point to `example.rs` (which corresponds to the `example` package defined in `person.proto`).
    - Enabling the code and its tests.
Verified the changes with `cargo test -p encoding --example binary_encoders`.

Fixes #1417

---
*PR created automatically by Jules for task [17566640550526361515](https://jules.google.com/task/17566640550526361515) started by @john-cd*