### PR TITLE
feat: uncomment and fix windows crate example

### DIFF
--- a/bk/crates/Cargo.lock
+++ b/bk/crates/Cargo.lock
@@ -1409,7 +1409,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2462,7 +2462,7 @@ dependencies = [
  "num-traits 0.2.19",
  "serde 1.0.228",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -6315,7 +6315,7 @@ checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
 dependencies = [
  "cfg-if 1.0.4",
  "libc",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -9358,6 +9358,7 @@ name = "os_windows_apis"
 version = "0.1.2"
 dependencies = [
  "winapi",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -9517,7 +9518,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -16344,6 +16345,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16357,15 +16380,39 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement 0.60.2",
  "windows-interface 0.59.3",
- "windows-link",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
- "windows-strings",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading",
 ]
 
 [[package]]
@@ -16414,9 +16461,25 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-registry"
@@ -16424,9 +16487,9 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
- "windows-strings",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -16440,11 +16503,29 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -16453,7 +16534,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -16498,7 +16579,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -16538,7 +16619,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -16547,6 +16628,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]

--- a/bk/crates/cats/os_windows_apis/Cargo.toml
+++ b/bk/crates/cats/os_windows_apis/Cargo.toml
@@ -17,5 +17,5 @@ autolib = false
 [dependencies]
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "0.3.9", features = ["winuser"] }
-# FIXME windows = { version = "0.61.1" }
+winapi = { version = "0.3.9", features = ["winuser", "libloaderapi", "minwindef"] }
+windows = { version = "0.61.1", features = ["Win32_Foundation", "Win32_UI_WindowsAndMessaging"] }

--- a/bk/crates/cats/os_windows_apis/examples/windows/main.rs
+++ b/bk/crates/cats/os_windows_apis/examples/windows/main.rs
@@ -1,4 +1,7 @@
 mod winapi;
 mod windows;
 
-fn main() {}
+fn main() {
+    #[cfg(target_os = "windows")]
+    windows::main();
+}

--- a/bk/crates/cats/os_windows_apis/examples/windows/winapi.rs
+++ b/bk/crates/cats/os_windows_apis/examples/windows/winapi.rs
@@ -68,7 +68,7 @@ fn to_wstring(str: &str) -> Vec<u16> {
 }
 
 /// Basic Windows application with a message box.
-fn main() {
+pub fn main() {
     unsafe {
         let h_instance = GetModuleHandleW(null_mut());
         // Define the window class name.
@@ -124,7 +124,6 @@ fn main() {
 }
 // ANCHOR_END: example
 
-#[ignore = "Needs review"]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/bk/crates/cats/os_windows_apis/examples/windows/windows.rs
+++ b/bk/crates/cats/os_windows_apis/examples/windows/windows.rs
@@ -1,43 +1,36 @@
 #![allow(dead_code)]
-// // ANCHOR: example
-// // COMING SOON
-// // ANCHOR_END: example
-// //! This example demonstrates how to use the `windows` crate to call the
-// //! `MessageBoxW` function from the Windows API.
-// //! It displays a simple message box with the text "Hello, windows!" and
-// //! the title "Greetings".
-// #![cfg(target_os = "windows")]
+#![cfg(target_os = "windows")]
+//! This example demonstrates how to use the `windows` crate to call the
+//! `MessageBoxW` function from the Windows API.
+//! It displays a simple message box with the text "Hello, windows!" and
+//! the title "Greetings".
 
-// use windows::Win32::Foundation::HWND;
-// use windows::Win32::Foundation::PWSTR;
-// use windows::Win32::UI::WindowsAndMessaging::MB_OK;
-// use windows::Win32::UI::WindowsAndMessaging::MessageBoxW;
+use windows::core::w;
+use windows::Win32::UI::WindowsAndMessaging::MB_OK;
+use windows::Win32::UI::WindowsAndMessaging::MessageBoxW;
 
-// /// Simple Windows application that displays a message box
-// /// saying "Hello, windows!".
-// fn main() {
-//     unsafe {
-//         MessageBoxW(
-//             HWND(0),
-//             PWSTR(
-//                 "Hello, windows!"
-//                     .encode_utf16()
-//                     .collect::<Vec<u16>>()
-//                     .as_mut_ptr(),
-//             ),
-//             PWSTR(
-//                 "Greetings"
-//                     .encode_utf16()
-//                     .collect::<Vec<u16>>()
-//                     .as_mut_ptr(),
-//             ),
-//             MB_OK,
-//         );
-//     }
-// }
+// ANCHOR: example
+/// Simple Windows application that displays a message box
+/// saying "Hello, windows!".
+pub fn main() {
+    unsafe {
+        MessageBoxW(
+            None,
+            w!("Hello, windows!"),
+            w!("Greetings"),
+            MB_OK,
+        );
+    }
+}
+// ANCHOR_END: example
 
-// #[test]
-// fn test() {
-//     main();
-// }
-// // [finish](https://github.com/john-cd/rust_howto/issues/823)
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[ignore = "Displays a message box"]
+    fn test() {
+        main();
+    }
+}


### PR DESCRIPTION
Uncommented and updated the windows crate example in bk/crates/cats/os_windows_apis/examples/windows/windows.rs. Updated Cargo.toml with required features for both windows and winapi crates. Verified with cross-compilation for x86_64-pc-windows-msvc.

---
*PR created automatically by Jules for task [11670709412505514226](https://jules.google.com/task/11670709412505514226) started by @john-cd*